### PR TITLE
docs(readme): fix typos found on the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 Twilio Labs host a variety of open-source projects that were developed by people 
 at Twilio and the community. Every one of these projects welcomes contributions.
 
-Feel free to submit issues, fixes or suggestions to improvements for the projects.
+Feel free to submit issues, fixes, or suggestions to improvements for the projects.
 
-*We can't wait to see what you __build together__ with us*
+*We can't wait to see what you __build together__ with us.*
 
 ## Examples
 
@@ -24,7 +24,7 @@ Here are some projects that are currently active:
     - [serverless-framework-integration](https://github.com/twilio-labs/serverless-framework-integration) _Twilio Runtime Integration for Serverless Framework_
 - [plugin-token](https://github.com/twilio-labs/plugin-token) _A plugin for the Twilio CLI to generate access tokens for client-side SDKs_
 - [svg-to-react](https://github.com/twilio-labs/svg-to-react) _Tool that generates React components out of SVG files_
-- [plugin-flex-realtime-stats-dashboard](https://github.com/twilio-labs/plugin-flex-realtime-stats-dashboard) _Sample Twilio Flex plugin for a real time stats solution_
+- [plugin-flex-realtime-stats-dashboard](https://github.com/twilio-labs/plugin-flex-realtime-stats-dashboard) _Sample Twilio Flex plugin for a real-time stats solution_
 - [plugin-flex-outbound-dialpad](https://github.com/twilio-labs/plugin-flex-outbound-dialpad) _Sample Twilio Flex plugin for a dialpad solution that allows for conferencing and supervisor monitor_
 
 
@@ -39,4 +39,3 @@ Your safety and comfort are important to us. Codes of Conduct let everyone know 
 # License
 
 MIT
-


### PR DESCRIPTION
**Description:** I've found some typos and on the README file and fixed them.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
